### PR TITLE
Bump `php` from `~8.4.0` to `~8.4.0 || ~8.5.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "#StopGenocide"
     ],
     "require": {
-        "php": "~8.4.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ghostwriter/case-converter": "~2.1.0",
         "ghostwriter/clock": "~3.0.1",
         "ghostwriter/collection": "~2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1677d15fa4975ddcb4e080398d61db7b",
+    "content-hash": "e976bb25d812bc22b1f67b35e528ed90",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -8640,7 +8640,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.4.0"
+        "php": "~8.4.0 || ~8.5.0"
     },
     "platform-dev": {
         "ext-xdebug": "*"


### PR DESCRIPTION
Bumps `php` from `~8.4.0` to `~8.4.0 || ~8.5.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`