### PR TITLE
Update ghostwriter/coding-standard to version dev-main#37e10b1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1421,12 +1421,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "7a37416bde106d282828400bd55a870ae40c7707"
+                "reference": "37e10b19a241ffac3d608c033bc6fc56865712e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7a37416bde106d282828400bd55a870ae40c7707",
-                "reference": "7a37416bde106d282828400bd55a870ae40c7707",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/37e10b19a241ffac3d608c033bc6fc56865712e3",
+                "reference": "37e10b19a241ffac3d608c033bc6fc56865712e3",
                 "shasum": ""
             },
             "require": {
@@ -1466,7 +1466,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.2",
                 "phpunit/phpunit": "^12.4.4",
-                "symfony/var-dumper": "^7.3.5"
+                "symfony/var-dumper": "^8.0.0"
             },
             "default-branch": true,
             "bin": [
@@ -1574,7 +1574,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-27T08:54:13+00:00"
+            "time": "2025-11-27T10:34:03+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#7a37416` to `dev-main#37e10b1`.

This pull request changes the following file(s): 

- Update `composer.lock`