### PR TITLE
Update phpunit phar 13.0.0 to 13.0.1

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -8,6 +8,6 @@
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>
   <phar name="phpbench" version="^1.4.3" installed="1.4.3" location="./tools/phar/phpbench" copy="true"/>
   <phar name="phpdocumentor" version="^3.9.1" installed="3.9.1" location="./tools/phar/phpdocumentor" copy="true"/>
-  <phar name="phpunit" version="^13.0.0" installed="13.0.0" location="./tools/phar/phpunit" copy="true"/>
+  <phar name="phpunit" version="^13.0.1" installed="13.0.1" location="./tools/phar/phpunit" copy="true"/>
   <phar name="psalm" version="^6.15.0" installed="6.15.1" location="./tools/phar/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Updates phpunit phar file from 13.0.0 to 13.0.1.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/phpunit`