### PR TITLE
Update ghostwriter/config to version 2.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ghostwriter/case-converter": "^2.2.1",
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.1.0",
-        "ghostwriter/config": "^2.1.1",
+        "ghostwriter/config": "^2.1.2",
         "ghostwriter/container": "^7.0.0",
         "ghostwriter/event-dispatcher": "^6.1.1",
         "ghostwriter/filesystem": "^0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7c4319effedb46eaa2cfb1d509c3623",
+    "content-hash": "b73adfe23abc50c89dfe896ffd0e1941",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -225,16 +225,16 @@
         },
         {
             "name": "ghostwriter/config",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/config.git",
-                "reference": "11076c766c7e7c23a4e2806154f0e641edb686fa"
+                "reference": "108d04cba1435d0d2fe1e366f19da869ff9e5284"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/config/zipball/11076c766c7e7c23a4e2806154f0e641edb686fa",
-                "reference": "11076c766c7e7c23a4e2806154f0e641edb686fa",
+                "url": "https://api.github.com/repos/ghostwriter/config/zipball/108d04cba1435d0d2fe1e366f19da869ff9e5284",
+                "reference": "108d04cba1435d0d2fe1e366f19da869ff9e5284",
                 "shasum": ""
             },
             "require": {
@@ -243,9 +243,9 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/container": "^6.1.1",
+                "ghostwriter/container": "^7.0.0",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.1.3",
+                "phpunit/phpunit": "^13.1.7",
                 "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
@@ -297,7 +297,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-14T22:24:27+00:00"
+            "time": "2026-04-20T20:57:17+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `ghostwriter/config` dependency from `2.1.1` to `2.1.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`